### PR TITLE
Work with non alpine images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,11 @@
-FROM gcr.io/kaniko-project/executor:v0.7.0 AS kaniko
+FROM gcr.io/kaniko-project/executor:debug-v0.7.0
 
-FROM alpine:3.8
-
-# clone the official kaniko container into this one, env vars needs to be re-set
-COPY --from=kaniko / /
 ENV HOME /root
 ENV USER /root
 ENV SSL_CERT_DIR=/kaniko/ssl/certs
 ENV DOCKER_CONFIG /kaniko/.docker/
 ENV DOCKER_CREDENTIAL_GCR_CONFIG /kaniko/.config/gcloud/docker_credential_gcr_config.json
 
-RUN apk add --update --no-cache jq
-
 # add the wrapper which acts as a drone plugin
-COPY plugin.sh /usr/bin/
-ENTRYPOINT [ "/usr/bin/plugin.sh" ]
+COPY plugin.sh /kaniko/plugin.sh
+ENTRYPOINT [ "/kaniko/plugin.sh" ]

--- a/README.md
+++ b/README.md
@@ -2,10 +2,33 @@
 
 A thin shim-wrapper around the official [Google Kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access) Docker image to make it behave like the [Drone Docker plugin](http://plugins.drone.io/drone-plugins/drone-docker/).
 
+Example .drone.yml for Drone 1.0
+
+```yaml
+kind: pipeline
+name: default
+
+steps:
+- name: publish
+  image: banzaicloud/kaniko-plugin
+  settings:
+    registry: registry.example.com
+    repo: registry.example.com/example-project
+    tags: ${DRONE_COMMIT_SHA}
+    cache: true
+    build_args:
+    - COMMIT_SHA=${DRONE_COMMIT_SHA}
+    - COMMIT_AUTHOR_EMAIL=${DRONE_COMMIT_AUTHOR_EMAIL}
+    username:
+      from_secret: docker-username
+    password:
+      from_secret: docker-password
+```
+
 ## Test that it can build
 
 ```bash
-docker run -it --rm -w /src -v $PWD:/src -e DOCKER_USERNAME=${DOCKER_USERNAME} -e DOCKER_PASSWORD=${DOCKER_PASSWORD} -e PLUGIN_REPO=banzaicloud/kaniko-plugin-test -e PLUGIN_TAGS=test -e PLUGIN_DOCKERFILE=Dockerfile.test banzaicloud/kaniko-plugin
+docker run -it --rm -w /src -v $PWD:/src -e PLUGIN_USERNAME=${DOCKER_USERNAME} -e PLUGIN_PASSWORD=${DOCKER_PASSWORD} -e PLUGIN_REPO=banzaicloud/kaniko-plugin-test -e PLUGIN_TAGS=test -e PLUGIN_DOCKERFILE=Dockerfile.test banzaicloud/kaniko-plugin
 ```
 
 ## Test that caching works

--- a/plugin.sh
+++ b/plugin.sh
@@ -19,7 +19,6 @@ cat > /kaniko/.docker/config.json <<DOCKERJSON
 DOCKERJSON
 
 DOCKERFILE=${PLUGIN_DOCKERFILE:-Dockerfile}
-DESTINATION=${PLUGIN_REPO}:${PLUGIN_TAGS:-latest}
 CONTEXT=${PLUGIN_CONTEXT:-$PWD}
 LOG=${PLUGIN_LOG:-info}
 case "${PLUGIN_CACHE:-}" in
@@ -31,9 +30,15 @@ if [[ -n "${PLUGIN_BUILD_ARGS:-}" ]]; then
     BUILD_ARGS=$(echo "${PLUGIN_BUILD_ARGS}" | tr ',' '\n' | while read build_arg; do echo "--build-arg=${build_arg}"; done)
 fi
 
+if [[ -n "${PLUGIN_TAGS:-}" ]]; then
+    DESTINATIONS=$(echo "${PLUGIN_TAGS}" | tr ',' '\n' | while read tag; do echo "--destination=${PLUGIN_REPO}:${tag} "; done)
+else
+    DESTINATIONS="--destination=${PLUGIN_REPO}:latest"
+fi
+
 /kaniko/executor -v ${LOG} \
     --context=${CONTEXT} \
     --dockerfile=${DOCKERFILE} \
-    --destination=${DESTINATION} \
     --cache=${CACHE} \
+    ${DESTINATIONS} \
     ${BUILD_ARGS:-}

--- a/plugin.sh
+++ b/plugin.sh
@@ -4,17 +4,21 @@ set -euo pipefail
 
 export PATH=$PATH:/kaniko/
 
-DOCKER_AUTH=`echo -n "${DOCKER_USERNAME}:${DOCKER_PASSWORD}" | base64`
+if [[ -n "${PLUGIN_USERNAME}" ]]; then
+    DOCKER_AUTH=`echo -n "${PLUGIN_USERNAME}:${PLUGIN_PASSWORD}" | base64`
 
-cat > /kaniko/.docker/config.json <<DOCKERJSON
+    REGISTRY=${PLUGIN_REGISTRY:-https://index.docker.io/v1/}
+
+    cat > /kaniko/.docker/config.json <<DOCKERJSON
 {
     "auths": {
-        "https://index.docker.io/v1/": {
+        "${REGISTRY}": {
             "auth": "${DOCKER_AUTH}"
         }
     }
 }
 DOCKERJSON
+fi
 
 DOCKERFILE=${PLUGIN_DOCKERFILE:-Dockerfile}
 DESTINATION=${PLUGIN_REPO}:${PLUGIN_TAGS:-latest}


### PR DESCRIPTION
First: This is a great plugin.  Thank you so much for making it.

I discovered that this was not working when building an Ubuntu image.  I kept getting odd errors about `ln` not supporting some arguments and that configuration files like `/etc/openssl/openssl.conf` already existed.  I looked into it and realized you where starting this image off with alpine and kaniko assumes everything not in the whitelisted directories are to be added to the image, so it was as if I was installing ubuntu on top of alpine. 

The solution was to base the image off of kaniko's debug image, which has busybox installed in `/busybox`.  That also meant replacing `jq` with some posix shell script black magic.

I also added support for private registries.