### PR TITLE
fix parentheses when parsing multiple arguments

### DIFF
--- a/plugin.sh
+++ b/plugin.sh
@@ -30,11 +30,11 @@ if [[ "${PLUGIN_CACHE:-}" == "true" ]]; then
     CACHE="--cache=true"
 fi
 
-if [[ -n "${PLUGIN_BUILD_ARGS:-}" ]]; then
+if [ -n "${PLUGIN_BUILD_ARGS:-}" ]; then
     BUILD_ARGS=$(echo "${PLUGIN_BUILD_ARGS}" | tr ',' '\n' | while read build_arg; do echo "--build-arg=${build_arg}"; done)
 fi
 
-if [[ -n "${PLUGIN_TAGS:-}" ]]; then
+if [ -n "${PLUGIN_TAGS:-}" ]; then
     DESTINATIONS=$(echo "${PLUGIN_TAGS}" | tr ',' '\n' | while read tag; do echo "--destination=${PLUGIN_REPO}:${tag} "; done)
 else
     DESTINATIONS="--destination=${PLUGIN_REPO}:latest"


### PR DESCRIPTION
I had a problem with parsing multiple tags and arguments in drone ci. Error message was:
 error pushing image: getting tag for destination: tag can only contain the runes `abcdefghijklmnopqrstuvwxyz0123456789_-.ABCDEFGHIJKLMNOPQRSTUVWXYZ`