### PR TITLE
Add Ability To Skip Push

### DIFF
--- a/plugin.sh
+++ b/plugin.sh
@@ -43,8 +43,12 @@ fi
 
 if [ -n "${PLUGIN_TAGS:-}" ]; then
     DESTINATIONS=$(echo "${PLUGIN_TAGS}" | tr ',' '\n' | while read tag; do echo "--destination=${REGISTRY}/${PLUGIN_REPO}:${tag} "; done)
-else
+elif [ -n "${PLUGIN_REPO:-}" ]; then
     DESTINATIONS="--destination=${PLUGIN_REPO}:latest"
+else
+    DESTINATIONS="--no-push"
+    # Cache is not valid with --no-push
+    CACHE=""
 fi
 
 /kaniko/executor -v ${LOG} \


### PR DESCRIPTION
This adds the ability to build the image without pushing it by omitting the `tags` and `repo` options.

Resolves #16.