### PR TITLE
Allow skip-tls-verify option for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ steps:
     repo: registry.example.com/example-project
     tags: ${DRONE_COMMIT_SHA}
     cache: true
+    skip_tls_verify: false # set to true for testing registries ONLY with self-signed certs
     build_args:
     - COMMIT_SHA=${DRONE_COMMIT_SHA}
     - COMMIT_AUTHOR_EMAIL=${DRONE_COMMIT_AUTHOR_EMAIL}

--- a/plugin.sh
+++ b/plugin.sh
@@ -28,9 +28,14 @@ fi
 DOCKERFILE=${PLUGIN_DOCKERFILE:-Dockerfile}
 CONTEXT=${PLUGIN_CONTEXT:-$PWD}
 LOG=${PLUGIN_LOG:-info}
+EXTRA_OPTS=""
 
 if [[ -n "${PLUGIN_TARGET:-}" ]]; then
     TARGET="--target=${PLUGIN_TARGET}"
+fi
+
+if [[ "${PLUGIN_SKIP_TLS_VERIFY:-}" == "true" ]]; then
+    EXTRA_OPTS="--skip-tls-verify=true"
 fi
 
 if [[ "${PLUGIN_CACHE:-}" == "true" ]]; then
@@ -54,6 +59,7 @@ fi
 /kaniko/executor -v ${LOG} \
     --context=${CONTEXT} \
     --dockerfile=${DOCKERFILE} \
+    ${EXTRA_OPTS} \
     ${DESTINATIONS} \
     ${CACHE:-} \
     ${TARGET:-} \


### PR DESCRIPTION
For simple testing with registries with self-signed certs an additional kaniko option is required for publishing images. Since it is easier than providing custom ca to kaniko, I've added an additional option to the plugin.sh.