### PR TITLE
Enable use of .tags file for custom tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,35 @@ steps:
       from_secret: google-application-credentials
 ```
 
+## Use `.tags` file for tagging
+
+Similarily to official
+[drone-docker](https://github.com/drone-plugins/drone-docker) plugin you can use
+`.tags` file to embed some custom logic for creating tags for an image.
+
+```yaml
+kind: pipeline
+name: default
+
+steps:
+- name: build
+  image: golang
+  commands:
+      - go get 
+      - go build
+      - make versiontags > .tags
+- name: publish
+  image: banzaicloud/drone-kaniko
+  settings:
+    registry: registry.example.com 
+    repo: registry.example.com/example-project
+    # tags: ${DRONE_COMMIT_SHA} <= it must be left undefined 
+    username:
+      from_secret: docker-username
+    password:
+      from_secret: docker-password
+```
+
 ## Test that it can build
 
 ```bash

--- a/plugin.sh
+++ b/plugin.sh
@@ -48,6 +48,8 @@ fi
 
 if [ -n "${PLUGIN_TAGS:-}" ]; then
     DESTINATIONS=$(echo "${PLUGIN_TAGS}" | tr ',' '\n' | while read tag; do echo "--destination=${REGISTRY}/${PLUGIN_REPO}:${tag} "; done)
+elif [ -f .tags ]; then
+    DESTINATIONS=$(cat .tags| tr ',' '\n' | while read tag; do echo "--destination=${REGISTRY}/${PLUGIN_REPO}:${tag} "; done)
 elif [ -n "${PLUGIN_REPO:-}" ]; then
     DESTINATIONS="--destination=${PLUGIN_REPO}:latest"
 else


### PR DESCRIPTION
A similar feature to the one found in drone-docker plugin. Very useful when you want to create tags with some custom logic.