### PR TITLE
Add build_args_from_env option to mimic Docker plugin

### DIFF
--- a/plugin.sh
+++ b/plugin.sh
@@ -46,6 +46,14 @@ if [ -n "${PLUGIN_BUILD_ARGS:-}" ]; then
     BUILD_ARGS=$(echo "${PLUGIN_BUILD_ARGS}" | tr ',' '\n' | while read build_arg; do echo "--build-arg=${build_arg}"; done)
 fi
 
+if [ -n "${PLUGIN_BUILD_ARGS_FROM_ENV:-}" ]; then
+    BUILD_ARGS_FROM_ENV=$(echo "${PLUGIN_BUILD_ARGS_FROM_ENV}" | tr ',' '\n' | while read build_arg; do echo "--build-arg=${build_arg}=${!build_arg}"; done)
+fi
+
+echo "BUILD_ARGS_FROM_ENV"
+echo ${BUILD_ARGS_FROM_ENV:-}
+echo "BUILD_ARGS_FROM_ENV END"
+
 if [ -n "${PLUGIN_TAGS:-}" ]; then
     DESTINATIONS=$(echo "${PLUGIN_TAGS}" | tr ',' '\n' | while read tag; do echo "--destination=${REGISTRY}/${PLUGIN_REPO}:${tag} "; done)
 elif [ -f .tags ]; then

--- a/plugin.sh
+++ b/plugin.sh
@@ -47,12 +47,8 @@ if [ -n "${PLUGIN_BUILD_ARGS:-}" ]; then
 fi
 
 if [ -n "${PLUGIN_BUILD_ARGS_FROM_ENV:-}" ]; then
-    BUILD_ARGS_FROM_ENV=$(echo "${PLUGIN_BUILD_ARGS_FROM_ENV}" | tr ',' '\n' | while read build_arg; do echo "--build-arg=${build_arg}=${!build_arg}"; done)
+    BUILD_ARGS_FROM_ENV=$(echo "${PLUGIN_BUILD_ARGS_FROM_ENV}" | tr ',' '\n' | while read build_arg; do echo "--build-arg ${build_arg}=$(eval "echo \$$build_arg")"; done)
 fi
-
-echo "BUILD_ARGS_FROM_ENV"
-echo ${BUILD_ARGS_FROM_ENV:-}
-echo "BUILD_ARGS_FROM_ENV END"
 
 if [ -n "${PLUGIN_TAGS:-}" ]; then
     DESTINATIONS=$(echo "${PLUGIN_TAGS}" | tr ',' '\n' | while read tag; do echo "--destination=${REGISTRY}/${PLUGIN_REPO}:${tag} "; done)
@@ -73,4 +69,5 @@ fi
     ${DESTINATIONS} \
     ${CACHE:-} \
     ${TARGET:-} \
-    ${BUILD_ARGS:-}
+    ${BUILD_ARGS:-} \
+    ${BUILD_ARGS_FROM_ENV:-}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | None
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This pull request adds the `build_args_from_env` option that the docker plugin already supports. It allows you to pass secrets to your docker containers as build arguments.

The behaviour is described by Brad here: https://discourse.drone.io/t/passing-secrets-as-build-arguments-plugins-docker/1835/4 (I could not find the official documentation for this behaviour)


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To be able to pass secrets through environment variables.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
As the original kaniko plugin uses busybox-sh or ash, it does not support parameter expansion like bash (`${!ENVIRONMENT_VARIABLE}`), I have opted to use eval instead as a work-around (suggested here: https://stackoverflow.com/questions/1014522/ash-variable-indirect-reference)

As eval can be a bit sketchy, and this might not be ok, I hope this PR can open a discussion around how this feature can be supported.

