### PR TITLE
fix: destination lack ${REGISTRY}

### DIFF
--- a/plugin.sh
+++ b/plugin.sh
@@ -55,7 +55,7 @@ if [ -n "${PLUGIN_TAGS:-}" ]; then
 elif [ -f .tags ]; then
     DESTINATIONS=$(cat .tags| tr ',' '\n' | while read tag; do echo "--destination=${REGISTRY}/${PLUGIN_REPO}:${tag} "; done)
 elif [ -n "${PLUGIN_REPO:-}" ]; then
-    DESTINATIONS="--destination=${PLUGIN_REPO}:latest"
+    DESTINATIONS="--destination=${REGISTRY}/${PLUGIN_REPO}:latest"
 else
     DESTINATIONS="--no-push"
     # Cache is not valid with --no-push


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
The lack of `${REGISTRY}`  in last `DESTINATION` variable cause we need to write registry in repo, like this:
```yaml
    registry: cr.private.com
    repo: cr.private.com/base/base
```

but when use `tags` or `.tag` file,  only need repo name
```yaml
    registry: cr.private.com
    repo: base/base
```

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Uniform the `repo` variable behavior

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
