### PR TITLE
Update Kaniko version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:debug-v0.10.0
+FROM gcr.io/kaniko-project/executor:debug-v0.16.0
 
 ENV HOME /root
 ENV USER root


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no


### What's in this PR?

Update Kaniko from version 0.10 to version 0.16

### Why?

The Kaniko team has fixed a number of issues between version 0.10 and 0.16. 

Main fix we need is:
https://github.com/GoogleContainerTools/kaniko/issues/589

