### PR TITLE
configurable cache repository and ttl

### DIFF
--- a/plugin.sh
+++ b/plugin.sh
@@ -42,6 +42,14 @@ if [[ "${PLUGIN_CACHE:-}" == "true" ]]; then
     CACHE="--cache=true"
 fi
 
+if [ -n "${PLUGIN_CACHE_REPO:-}" ]; then
+    CACHE_REPO="--cache-repo=${REGISTRY}/${PLUGIN_CACHE_REPO}"
+fi
+
+if [ -n "${PLUGIN_CACHE_TTL:-}" ]; then
+    CACHE_TTL="--cache-ttl=${PLUGIN_CACHE_TTL}"
+fi
+
 if [ -n "${PLUGIN_BUILD_ARGS:-}" ]; then
     BUILD_ARGS=$(echo "${PLUGIN_BUILD_ARGS}" | tr ',' '\n' | while read build_arg; do echo "--build-arg=${build_arg}"; done)
 fi
@@ -94,6 +102,8 @@ fi
     ${EXTRA_OPTS} \
     ${DESTINATIONS} \
     ${CACHE:-} \
+    ${CACHE_TTL:-} \
+    ${CACHE_REPO:-} \
     ${TARGET:-} \
     ${BUILD_ARGS:-} \
     ${BUILD_ARGS_FROM_ENV:-}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Allowes to configures kanikos `--cache-ttl` and `--cache-repo` options.

### Why?

A shared cache repo can be very useful when building multistage images that share stages.

Cache timeouts are sometimes just required.

